### PR TITLE
Change floor activity to watch instead of streaming

### DIFF
--- a/board.go
+++ b/board.go
@@ -183,7 +183,7 @@ func (b *Board) watchStockPrice() {
 						}
 					}
 
-					err = dg.UpdateGameStatus(0, b.Name)
+					err = dg.UpdateWatchStatus(0, b.Name)
 					if err != nil {
 						logger.Errorf("Unable to set activity: %s\n", err)
 					} else {
@@ -200,7 +200,7 @@ func (b *Board) watchStockPrice() {
 						activity = fmt.Sprintf("%s %s %s $%s", symbol, fmtPrice, decorator, fmtDiff)
 					}
 
-					err = dg.UpdateGameStatus(0, activity)
+					err = dg.UpdateWatchStatus(0, activity)
 					if err != nil {
 						logger.Errorf("Unable to set activity: %s\n", err)
 					} else {
@@ -357,7 +357,7 @@ func (b *Board) watchCryptoPrice() {
 						}
 					}
 
-					err = dg.UpdateGameStatus(0, b.Name)
+					err = dg.UpdateWatchStatus(0, b.Name)
 					if err != nil {
 						logger.Errorf("Unable to set activity: %s\n", err)
 					} else {
@@ -368,7 +368,7 @@ func (b *Board) watchCryptoPrice() {
 
 					// format activity
 					activity := fmt.Sprintf("%s $%s %s %s", strings.ToUpper(priceData.Symbol), fmtPrice, decorator, fmtDiff)
-					err = dg.UpdateGameStatus(0, activity)
+					err = dg.UpdateWatchStatus(0, activity)
 					if err != nil {
 						logger.Errorf("Unable to set activity: %s\n", err)
 					} else {

--- a/circulating.go
+++ b/circulating.go
@@ -199,7 +199,7 @@ func (c *Circulating) watchCirculating() {
 				}
 
 				// set activity
-				err = dg.UpdateGameStatus(0, c.Activity)
+				err = dg.UpdateWatchStatus(0, c.Activity)
 				if err != nil {
 					logger.Errorf("Unable to set activity: %s", err)
 				} else {
@@ -209,7 +209,7 @@ func (c *Circulating) watchCirculating() {
 			} else {
 
 				// format activity
-				err = dg.UpdateGameStatus(0, c.Activity)
+				err = dg.UpdateWatchStatus(0, c.Activity)
 				if err != nil {
 					logger.Errorf("Unable to set activity: %s", err)
 				} else {

--- a/floor.go
+++ b/floor.go
@@ -172,7 +172,7 @@ func (f *Floor) watchFloorPrice() {
 					}
 				}
 
-				err = dg.UpdateGameStatus(0, f.Activity)
+				err = dg.UpdateWatchStatus(0, f.Activity)
 				if err != nil {
 					logger.Errorf("Unable to set activity: %s\n", err)
 				} else {

--- a/gas.go
+++ b/gas.go
@@ -114,7 +114,7 @@ func (g *Gas) watchGasPrice() {
 					time.Sleep(time.Duration(g.Frequency) * time.Second)
 				}
 
-				err = dg.UpdateGameStatus(0, "Fast, Avg, Slow")
+				err = dg.UpdateWatchStatus(0, "Fast, Avg, Slow")
 				if err != nil {
 					logger.Errorf("Unable to set activity: %s\n", err)
 				} else {
@@ -122,7 +122,7 @@ func (g *Gas) watchGasPrice() {
 				}
 			} else {
 
-				err = dg.UpdateGameStatus(0, nickname)
+				err = dg.UpdateWatchStatus(0, nickname)
 				if err != nil {
 					logger.Errorf("Unable to set activity: %s\n", err)
 				} else {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/PuerkitoBio/goquery v1.7.1
-	github.com/bwmarrin/discordgo v0.26.1
+	github.com/bwmarrin/discordgo v0.27.0
 	github.com/go-redis/redis/v8 v8.8.2
 	github.com/gorilla/mux v1.8.0
 	github.com/namsral/flag v1.7.4-pre

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/bwmarrin/discordgo v0.23.2 h1:BzrtTktixGHIu9Tt7dEE6diysEF9HWnXeHuoJEt
 github.com/bwmarrin/discordgo v0.23.2/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/bwmarrin/discordgo v0.26.1 h1:AIrM+g3cl+iYBr4yBxCBp9tD9jR3K7upEjl0d89FRkE=
 github.com/bwmarrin/discordgo v0.26.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
+github.com/bwmarrin/discordgo v0.27.0 h1:4ZK9KN+rGIxZ0fdGTmgdCcliQeW8Zhu6MnlFI92nf0Q=
+github.com/bwmarrin/discordgo v0.27.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/holders.go
+++ b/holders.go
@@ -57,7 +57,7 @@ func (h *Holders) watchHolders() {
 
 	// set activity as desc
 	if h.Nickname {
-		err = dg.UpdateGameStatus(0, h.Activity)
+		err = dg.UpdateWatchStatus(0, h.Activity)
 		if err != nil {
 			logger.Errorf("Unable to set activity: %s\n", err)
 		} else {
@@ -117,7 +117,7 @@ func (h *Holders) watchHolders() {
 				}
 			} else {
 
-				err = dg.UpdateGameStatus(0, nickname)
+				err = dg.UpdateWatchStatus(0, nickname)
 				if err != nil {
 					logger.Errorf("Unable to set activity: %s\n", err)
 				} else {

--- a/marketcap.go
+++ b/marketcap.go
@@ -286,7 +286,7 @@ func (m *MarketCap) watchMarketCap() {
 				}
 
 				// set activity
-				err = dg.UpdateGameStatus(0, activity)
+				err = dg.UpdateWatchStatus(0, activity)
 				if err != nil {
 					logger.Errorf("Unable to set activity: %s", err)
 				} else {
@@ -297,7 +297,7 @@ func (m *MarketCap) watchMarketCap() {
 
 				// format activity
 				activity := fmt.Sprintf("%s %s %s%%", fmtPrice, m.Decorator, fmtDiffPercent)
-				err = dg.UpdateGameStatus(0, activity)
+				err = dg.UpdateWatchStatus(0, activity)
 				if err != nil {
 					logger.Errorf("Unable to set activity: %s", err)
 				} else {

--- a/ticker.go
+++ b/ticker.go
@@ -275,7 +275,7 @@ func (s *Ticker) watchStockPrice() {
 					}
 				}
 
-				err = dg.UpdateGameStatus(0, activity)
+				err = dg.UpdateWatchStatus(0, activity)
 				if err != nil {
 					logger.Errorf("Unable to set activity: %s", err)
 				} else {
@@ -285,7 +285,7 @@ func (s *Ticker) watchStockPrice() {
 			} else {
 				activity := fmt.Sprintf("%s %s %s", fmtPrice, s.Decorator, fmtDiffPercent)
 
-				err = dg.UpdateGameStatus(0, activity)
+				err = dg.UpdateWatchStatus(0, activity)
 				if err != nil {
 					logger.Errorf("Unable to set activity: %s", err)
 				} else {
@@ -633,7 +633,7 @@ func (s *Ticker) watchCryptoPrice() {
 				// set activity
 				wg := sync.WaitGroup{}
 				for _, sess := range shards {
-					err = sess.UpdateGameStatus(0, activity)
+					err = sess.UpdateWatchStatus(0, activity)
 					if err != nil {
 						logger.Errorf("Unable to set activity: %s", err)
 					} else {
@@ -650,7 +650,7 @@ func (s *Ticker) watchCryptoPrice() {
 
 				wg := sync.WaitGroup{}
 				for _, sess := range shards {
-					err = sess.UpdateGameStatus(0, activity)
+					err = sess.UpdateWatchStatus(0, activity)
 					if err != nil {
 						logger.Errorf("Unable to set activity: %s", err)
 					} else {

--- a/token.go
+++ b/token.go
@@ -295,7 +295,7 @@ func (t *Token) watchTokenPrice() {
 					}
 				}
 
-				err = dg.UpdateGameStatus(0, activity)
+				err = dg.UpdateWatchStatus(0, activity)
 				if err != nil {
 					logger.Error("Unable to set activity: ", err)
 				} else {
@@ -305,7 +305,7 @@ func (t *Token) watchTokenPrice() {
 			} else {
 				activity := formatActivity(t, fmtPrice)
 
-				err = dg.UpdateGameStatus(0, activity)
+				err = dg.UpdateWatchStatus(0, activity)
 				if err != nil {
 					logger.Error("Unable to set activity: ", err)
 				} else {

--- a/valuelocked.go
+++ b/valuelocked.go
@@ -215,7 +215,7 @@ func (m *ValueLocked) watchValueLocked() {
 				}
 
 				// set activity
-				err = dg.UpdateGameStatus(0, m.Activity)
+				err = dg.UpdateWatchStatus(0, m.Activity)
 				if err != nil {
 					logger.Errorf("Unable to set activity: %s", err)
 				} else {
@@ -225,7 +225,7 @@ func (m *ValueLocked) watchValueLocked() {
 			} else {
 
 				// format activity
-				err = dg.UpdateGameStatus(0, nickname)
+				err = dg.UpdateWatchStatus(0, nickname)
 				if err != nil {
 					logger.Errorf("Unable to set activity: %s", err)
 				} else {


### PR DESCRIPTION
This PR uses the new UpdateWatchStatus of https://github.com/bwmarrin/discordgo/pull/1291 to set the activity to watching instead of streaming. It follows up on #180.

![image](https://user-images.githubusercontent.com/17570430/204558440-a0686461-2c35-42b3-bf41-ac833c0d0795.png)

> **Warning**
> This PR contains a feature of discordgo that has not yet been released please merge after https://github.com/bwmarrin/discordgo/pull/1291 has been released.