### PR TITLE
feat: add scientific format to token ticker

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Tracks stock or crypto prices. Uses Yahoo for stock or CoinGecko for crypto.
   "pair": "binancecoin",                            # string/OPTIONAL: pair the coin with another coin, replaces activity section
   "pair_flip": true,                                # bool/OPTIONAL: show <pair>/<coin> rather than <coin>/<pair>
   "activity": "Hello;Its;Me",                       # string/OPTIONAL: list of strings to show in activity section
-  "decimals": 3,                                    # int/OPTIONAL: set number of decimal places
+  "decimals": 3,                                    # int/OPTIONAL: set number of decimal places. Use -1 for scientific notation.
   "nickname": true,                                 # bool/OPTIONAL: display information in nickname vs activity
   "frequency": 10,                                  # int/OPTIONAL: seconds between refresh
   "discord_bot_token": "xxxxxxxxxxxxxxxxxxxxxxxx"   # string: dicord bot token

--- a/token.go
+++ b/token.go
@@ -38,6 +38,24 @@ func (t *Token) label() string {
 	return label
 }
 
+// Format nickname
+func formatNickname(t *Token, price float64) string {
+	if t.Decimals == -1 {
+		return fmt.Sprintf("%s %s $%.2e", t.Name, t.Decorator, price)
+	} else {
+		return fmt.Sprintf("%s %s $%."+strconv.Itoa(t.Decimals)+"f", t.Name, t.Decorator, price)
+	}
+}
+
+// Format activity when not using nickname
+func formatActivity(t *Token, price float64) string {
+	if t.Decimals == -1 {
+		return fmt.Sprintf("%s %s $%.2e", t.Name, t.Decorator, price)
+	} else {
+		return fmt.Sprintf("%s %s $%."+strconv.Itoa(t.Decimals)+"f", t.Name, t.Decorator, price)
+	}
+}
+
 func (t *Token) Shutdown() {
 	t.close <- 1
 }
@@ -198,34 +216,7 @@ func (t *Token) watchTokenPrice() {
 
 				// format nickname & activity
 				// Check for custom decimal places
-				switch t.Decimals {
-				case 0:
-					nickname = fmt.Sprintf("%s %s $%.0f", t.Name, t.Decorator, fmtPrice)
-				case 1:
-					nickname = fmt.Sprintf("%s %s $%.1f", t.Name, t.Decorator, fmtPrice)
-				case 2:
-					nickname = fmt.Sprintf("%s %s $%.2f", t.Name, t.Decorator, fmtPrice)
-				case 3:
-					nickname = fmt.Sprintf("%s %s $%.3f", t.Name, t.Decorator, fmtPrice)
-				case 4:
-					nickname = fmt.Sprintf("%s %s $%.4f", t.Name, t.Decorator, fmtPrice)
-				case 5:
-					nickname = fmt.Sprintf("%s %s $%.5f", t.Name, t.Decorator, fmtPrice)
-				case 6:
-					nickname = fmt.Sprintf("%s %s $%.6f", t.Name, t.Decorator, fmtPrice)
-				case 7:
-					nickname = fmt.Sprintf("%s %s $%.7f", t.Name, t.Decorator, fmtPrice)
-				case 8:
-					nickname = fmt.Sprintf("%s %s $%.8f", t.Name, t.Decorator, fmtPrice)
-				case 9:
-					nickname = fmt.Sprintf("%s %s $%.9f", t.Name, t.Decorator, fmtPrice)
-				case 10:
-					nickname = fmt.Sprintf("%s %s $%.10f", t.Name, t.Decorator, fmtPrice)
-				case 11:
-					nickname = fmt.Sprintf("%s %s $%.11f", t.Name, t.Decorator, fmtPrice)
-				default:
-					nickname = fmt.Sprintf("%s %s $%.4f", t.Name, t.Decorator, fmtPrice)
-				}
+				nickname = formatNickname(t, fmtPrice)
 
 				// Update nickname in guilds
 				for _, g := range guilds {
@@ -312,7 +303,7 @@ func (t *Token) watchTokenPrice() {
 				}
 
 			} else {
-				activity := fmt.Sprintf("%s %s $%.2f", t.Name, t.Decorator, fmtPrice)
+				activity := formatActivity(t, fmtPrice)
 
 				err = dg.UpdateGameStatus(0, activity)
 				if err != nil {


### PR DESCRIPTION
This commit adds the ability to use the scientific format to the token ticker. This feature can be enabled by setting the `Decimals` parameter to `-1`. I only added this to the token ticker since I was not sure if you also wanted this applied to the other tickers.
